### PR TITLE
Update SoftDelete.php

### DIFF
--- a/behaviors/SoftDelete.php
+++ b/behaviors/SoftDelete.php
@@ -2,7 +2,6 @@
 
 namespace amnah\yii2\behaviors;
 
-use yii\behaviors\AutoTimestamp;
 use yii\base\Event;
 use yii\db\ActiveRecord;
 
@@ -72,7 +71,7 @@ class SoftDelete extends AutoTimestamp {
     public function remove() {
 
         // evaluate timestamp and set attribute
-        $timestamp = $this->evaluateTimestamp();
+        $timestamp = time();
         $attribute = $this->attribute;
         $this->owner->$attribute = $timestamp;
 


### PR DESCRIPTION
AutoTimestamp don't exist anymore. I remove "use yii\behaviors\AutoTimestamp;" from line 5 and change "$timestamp = $this->evaluateTimestamp();" from line 75 to "$timestamp = time();"
